### PR TITLE
Fix PATH if script is run from different directory

### DIFF
--- a/s3-utils/s3-setup.sh
+++ b/s3-utils/s3-setup.sh
@@ -2,4 +2,4 @@
 export S3_URL=http://$DUMMY_IP:9000
 export S3_ACCESS=$S3_ACCESS
 export S3_SECRET=$S3_SECRET
-export PATH=$PATH:$(readlink -f $(dirname $0)/bin/)
+export PATH=$PATH:$(readlink -f $(dirname ${BASH_SOURCE[0]})/bin)

--- a/s3-utils/s3-setup.sh
+++ b/s3-utils/s3-setup.sh
@@ -2,4 +2,4 @@
 export S3_URL=http://$DUMMY_IP:9000
 export S3_ACCESS=$S3_ACCESS
 export S3_SECRET=$S3_SECRET
-export PATH=$PATH:$(readlink -f bin/)
+export PATH=$PATH:$(readlink -f $(dirname $0)/bin/)


### PR DESCRIPTION
If running `s3-setup.sh` e.g. from the ochami-vm repo root:

```sh
[user@host ochami-vm]$ pwd
/home/user/ochami-vm
[user@host ochami-vm]$ ./s3-utils/s3-setup.sh
[user@host ochami-vm]$ echo $PATH
...:/home/user/ochami-vm/bin
```

Running `s3-setup.sh` puts '/home/user/ochami-vm/bin' in the `PATH` when it should be '/home/user/ochami-vm/s3-utils/bin'.

This commit fixes this so no matter from which working directory the script is run from, the correct path is put into `PATH`.