### PR TITLE
Various script fixes

### DIFF
--- a/s3-utils/s3-setup.sh
+++ b/s3-utils/s3-setup.sh
@@ -2,4 +2,4 @@
 export S3_URL=http://$DUMMY_IP:9000
 export S3_ACCESS=$S3_ACCESS
 export S3_SECRET=$S3_SECRET
-export PATH=$PATH:$(readlink -f bin/)
+export PATH=$PATH:$(readlink -f $(dirname ${BASH_SOURCE[0]})/bin)

--- a/vm-images/build-test-image-scratch.sh
+++ b/vm-images/build-test-image-scratch.sh
@@ -9,17 +9,28 @@ CNAME=$(buildah from scratch)
 MNAME=$(buildah mount $CNAME)
 REPO_DIR="${MNAME}/etc/yum.repos.d"
 
+mkdir -p ${MNAME}/var/log
+mkdir -p ${MNAME}/var/cache/dnf
+
 #Add extra repos here
 dnf config-manager --setopt=reposdir=${REPO_DIR} \
+	--setopt=logdir=${MNAME}/var/log \
+	--setopt=cachedir=${MNAME}/var/cache/dnf \
 	--add-repo https://download.docker.com/linux/centos/docker-ce.repo
 
 dnf config-manager --setopt=reposdir=${REPO_DIR} \
+	--setopt=logdir=${MNAME}/var/log \
+	--setopt=cachedir=${MNAME}/var/cache/dnf \
         --add-repo https://repo.almalinux.org/almalinux/8/BaseOS/x86_64/os
 
 dnf config-manager --setopt=reposdir=${REPO_DIR} \
+	--setopt=logdir=${MNAME}/var/log \
+	--setopt=cachedir=${MNAME}/var/cache/dnf \
         --add-repo https://repo.almalinux.org/almalinux/8/AppStream/x86_64/os
 
 dnf config-manager --setopt=reposdir=${REPO_DIR} \
+	--setopt=logdir=${MNAME}/var/log \
+	--setopt=cachedir=${MNAME}/var/cache/dnf \
         --add-repo https://repo.almalinux.org/almalinux/8/PowerTools/x86_64/os
 
 #Generate machine-id

--- a/vm-images/build-test-image.sh
+++ b/vm-images/build-test-image.sh
@@ -34,6 +34,12 @@ buildah run $CNAME dnf install -y \
         libssh \
 	NetworkManager-initscripts-updown
 
+# Unmask login service to allow login via console.
+buildah run $CNAME systemctl unmask systemd-logind
+
+# Unmask TTY target so login prompt will appear.
+buildah run $CNAME systemctl unmask getty.target
+
 #Update the initramfs so we can network mount the rootfs
 buildah run $CNAME bash -c "dracut \
 	--add \"dmsquash-live livenet network-manager\" \


### PR DESCRIPTION
Fixed:

`build-test-image.sh`:
- Login prompt not showing (unmask getty and systemd-logind)

`build-test-image-scratch.sh`:
- DNF cache not being found

`s3-utils.sh`:
- PATH is set right no matter from where script is sourced from.